### PR TITLE
Formatting with Black

### DIFF
--- a/pyms/crystal.py
+++ b/pyms/crystal.py
@@ -19,6 +19,7 @@ from .utils.torch_utils import (
     amplitude,
 )
 
+
 def Xray_scattering_factor(Z, gsq, units="A"):
     # Bohr radius in Angstrom
     a0 = 0.529177
@@ -50,34 +51,37 @@ def electron_scattering_factor(Z, gsq, units="VA"):
     elif units == "A":
         return fe
 
-def find_equivalent_sites(positions,EPS=1e-3):
+
+def find_equivalent_sites(positions, EPS=1e-3):
     """Finds equivalent atomic sites, ie two atoms sharing the same 
     postions with fractional occupancy, and return an index of these equivalent
     sites"""
     from scipy.spatial.distance import pdist
+
     natoms = positions.shape[0]
-    #Calculate pairwise distance between each atomic site
+    # Calculate pairwise distance between each atomic site
     distance_matrix = pdist(positions)
 
-    #Initialize index of equivalent sites (initially assume all sites are
+    # Initialize index of equivalent sites (initially assume all sites are
     # independent)
-    equivalent_sites = np.arange(natoms,dtype=np.int)
+    equivalent_sites = np.arange(natoms, dtype=np.int)
 
-    #Find equivalent sites
-    equiv = distance_matrix<EPS
-    
-    #If there are equivalent sites correct the index of equivalent sites
+    # Find equivalent sites
+    equiv = distance_matrix < EPS
+
+    # If there are equivalent sites correct the index of equivalent sites
     if np.any(equiv):
-        #Masking function to get indices from distance_matrix
-        iu = np.mask_indices(natoms, np.triu,1)
+        # Masking function to get indices from distance_matrix
+        iu = np.mask_indices(natoms, np.triu, 1)
 
-        #Get a list of equivalent sites
+        # Get a list of equivalent sites
         sites = np.nonzero(equiv)[0]
         for site in sites:
-            #Use the masking function to 
+            # Use the masking function to
             equivalent_sites[iu[1][site]] = iu[0][site]
     print(equivalent_sites)
     return equivalent_sites
+
 
 def interaction_constant(E, units="rad/VA"):
     """Calculates the interaction constant, sigma, to convert electrostatic
@@ -98,7 +102,6 @@ def interaction_constant(E, units="rad/VA"):
         return 2 * np.pi * gamma * me * qe / k0 / h / h
     elif units == "rad/A":
         return gamma / k0
-
 
 
 def rot_matrix(theta, u=np.asarray([0, 0, 1], dtype=np.float)):
@@ -128,8 +131,6 @@ def rot_matrix(theta, u=np.asarray([0, 0, 1], dtype=np.float)):
     return R
 
 
-
-
 class crystal:
     # Elements in a crystal object:
     # unitcell - An array containing the side lengths of the orthorhombic unit cell
@@ -141,9 +142,14 @@ class crystal:
     #        the atomic occupancy (not yet implemented in the multislice) in the
     #        fifth entry and mean squared atomic displacement in the sixth entry
     #
-    def __init__(self, fnam, temperature_factor_units="urms",
-                atomic_coordinates = "fractional", EPS=1e-2,
-                psuedo_rational_tiling=1e-2):
+    def __init__(
+        self,
+        fnam,
+        temperature_factor_units="urms",
+        atomic_coordinates="fractional",
+        EPS=1e-2,
+        psuedo_rational_tiling=1e-2,
+    ):
         """Initializes a crystal object by reading in a *.p1 file, which is
         outputted by the vesta software:
 
@@ -168,9 +174,9 @@ class crystal:
 
             # Get unit cell vector - WARNING assume an orthorhombic unit cell
             self.unitcell = np.loadtxt(f, max_rows=3, dtype=np.float)
-            
+
             # Check to see if unit cell is orthorhombic
-            ortho = np.abs(np.sum(self.unitcell)-np.trace(self.unitcell))<EPS
+            ortho = np.abs(np.sum(self.unitcell) - np.trace(self.unitcell)) < EPS
 
             # Get the atomic symbol of each element
             self.atomtypes = np.loadtxt(f, max_rows=1, dtype=str, ndmin=1)
@@ -199,7 +205,7 @@ class crystal:
                     match("([A-Za-z]+)", atominfo[3]).group(0)
                 )
                 self.atoms[i, 4:6] = np.asarray(atominfo[4:6], dtype=np.float)
-            
+
             if ortho:
                 # If unit cell is orthorhombic then extract unit cell
                 # dimension
@@ -243,43 +249,47 @@ class crystal:
             self.atoms[:, 5] /= 8 * np.pi ** 2
 
         # If necessary, Convert atomic positions to fractional coordinates
-        if atomic_coordinates == 'cartesian':
+        if atomic_coordinates == "cartesian":
             self.atoms[:, :3] /= self.unitcell[:3][np.newaxis, :]
-        
+
         # Build list of equivalent sites
-        self.equivalent_sites = find_equivalent_sites(self.atoms[:,:3])
-    
-    def orthorhombic_supercell(self,EPS):
+        self.equivalent_sites = find_equivalent_sites(self.atoms[:, :3])
+
+    def orthorhombic_supercell(self, EPS):
         # If not orthorhombic attempt psuedo rational tiling
         # (only implemented for hexagonal structures)
-        tiley = int(np.round(np.abs(self.unitcell[1,0]/self.unitcell[0,0])/EPS))
-        tilex = int(np.round(1/EPS))
+        tiley = int(np.round(np.abs(self.unitcell[1, 0] / self.unitcell[0, 0]) / EPS))
+        tilex = int(np.round(1 / EPS))
 
-        #Remove common denominators
+        # Remove common denominators
         from math import gcd
-        g_ = gcd(tiley,tilex)
-        while (g_>1):
-            tiley = tiley//g_
-            tilex = tilex//g_
-            g_ = gcd(tiley,tilex)
 
-        #Make deepcopy of old unit cell    
+        g_ = gcd(tiley, tilex)
+        while g_ > 1:
+            tiley = tiley // g_
+            tilex = tilex // g_
+            g_ = gcd(tiley, tilex)
+
+        # Make deepcopy of old unit cell
         import copy
+
         olduc = copy.deepcopy(self.unitcell)
 
-        #Calculate length of unit cell sides
-        self.unitcell = np.sqrt(np.sum(np.square(self.unitcell),axis=1))
-        
-        #Tile out atoms
-        self.tile(tiley,tilex,1)
-        
-        #Calculate size of old unit cell under tiling
-        olduc = np.asarray([tiley,tilex,1])[:,np.newaxis]*olduc
-        
+        # Calculate length of unit cell sides
+        self.unitcell = np.sqrt(np.sum(np.square(self.unitcell), axis=1))
+
+        # Tile out atoms
+        self.tile(tiley, tilex, 1)
+
+        # Calculate size of old unit cell under tiling
+        olduc = np.asarray([tiley, tilex, 1])[:, np.newaxis] * olduc
+
         self.unitcell = np.diag(olduc)
-        
-        #Now calculate fractional coordinates in new orthorhombic cell
-        self.atoms[:,:3] = np.mod(self.atoms[:,:3] @ olduc @ np.diag(1/self.unitcell),1.0)
+
+        # Now calculate fractional coordinates in new orthorhombic cell
+        self.atoms[:, :3] = np.mod(
+            self.atoms[:, :3] @ olduc @ np.diag(1 / self.unitcell), 1.0
+        )
 
     def quickplot(self, atomscale=0.01, cmap=plt.get_cmap("Dark2")):
         """Makes a quick 3D scatter plot of the crystal"""
@@ -289,8 +299,9 @@ class crystal:
         ax = fig.add_subplot(111, projection="3d")
         colors = cmap(self.atoms[:, 3] / np.amax(self.atoms[:, 3]))
         sizes = self.atoms[:, 3] ** (4) * atomscale
-        ax.scatter(*[self.atoms[:, i] for i in range(3)], c=colors, s=sizes)        
-        for fun in [ax.set_xlim3d,ax.set_ylim3d,ax.set_zlim3d]:fun(0, 1.0)
+        ax.scatter(*[self.atoms[:, i] for i in range(3)], c=colors, s=sizes)
+        for fun in [ax.set_xlim3d, ax.set_ylim3d, ax.set_zlim3d]:
+            fun(0, 1.0)
         plt.show(block=True)
 
     def output_vesta_xtl(self, fnam):
@@ -313,16 +324,19 @@ class crystal:
             )
         f.write("EOF")
         f.close()
-    
-    def output_xyz(self,fnam,atomic_coordinates="cartesian"):
+
+    def output_xyz(self, fnam, atomic_coordinates="cartesian"):
         f = open(splitext(fnam)[0] + ".xyz", "w")
-        f.write(self.Title+'\n {0:.4f} {1:.4f} {2:.4f}\n'.format(*self.unitcell))
+        f.write(self.Title + "\n {0:.4f} {1:.4f} {2:.4f}\n".format(*self.unitcell))
         print(self.atoms.shape)
         for atom in self.atoms:
-            f.write('{0:d} {1:.4f} {2:.4f} {3:.4f} {4:.2f}  {5:.3f}\n'
-                        .format(int(atom[3]),*(atom[:3]*self.unitcell),*atom[4:6]))
-        print(self.atoms.shape)                        
-        f.write('-1')
+            f.write(
+                "{0:d} {1:.4f} {2:.4f} {3:.4f} {4:.2f}  {5:.3f}\n".format(
+                    int(atom[3]), *(atom[:3] * self.unitcell), *atom[4:6]
+                )
+            )
+        print(self.atoms.shape)
+        f.write("-1")
         f.close()
 
     def make_transmission_functions(
@@ -336,7 +350,7 @@ class crystal:
         fftout=True,
         dtype=None,
         device=None,
-        fractional_occupancy = True
+        fractional_occupancy=True,
     ):
         """Make the transmission functions for this crystal, which are the
            exponential of the specimen potential scaled by the interaction
@@ -344,7 +358,14 @@ class crystal:
 
         # Make the specimen electrostatic potential
         T = self.make_potential(
-            pixels, subslices, tiling, fe=fe, displacements=displacements, device=device,dtype=dtype, fractional_occupancy=fractional_occupancy
+            pixels,
+            subslices,
+            tiling,
+            fe=fe,
+            displacements=displacements,
+            device=device,
+            dtype=dtype,
+            fractional_occupancy=fractional_occupancy,
         )
 
         # Now take the complex exponential of the electrostatic potential
@@ -359,7 +380,7 @@ class crystal:
         if fftout:
             return torch.ifft(T, signal_ndim=2)
         return T
-    
+
     def calculate_scattering_factors(self, pixels, tiling=[1, 1]):
         """Calculates the electron scattering factors on a reciprocal space
            grid of pixel size pixels assuming a unit cell tiling given by 
@@ -466,7 +487,7 @@ class crystal:
         )
 
         if displacements:
-            #Generate thermal displacements
+            # Generate thermal displacements
             urms = torch.tensor(
                 np.sqrt(self.atoms[:, 5])[:, np.newaxis] * pixperA[np.newaxis, :],
                 dtype=P.dtype,
@@ -497,10 +518,11 @@ class crystal:
                     * urms
                 )
 
-                #If using fractional occupancy force atoms occupying equivalent
-                #sites to have the same displacement
-                if fractional_occupancy: disp = disp[self.equivalent_sites,:]
-                
+                # If using fractional occupancy force atoms occupying equivalent
+                # sites to have the same displacement
+                if fractional_occupancy:
+                    disp = disp[self.equivalent_sites, :]
+
                 posn[:, :2] += disp
 
             yc = (
@@ -523,10 +545,10 @@ class crystal:
             xh = torch.remainder(posn[:, 1], 1.0)
             xl = 1.0 - xh
 
-            #Account for fractional occupancy of atomic sites if requested
+            # Account for fractional occupancy of atomic sites if requested
             if fractional_occupancy:
-                xh *= torch.from_numpy(self.atoms[:,4]).type(P.dtype).to(device)
-                xl *= torch.from_numpy(self.atoms[:,4]).type(P.dtype).to(device)
+                xh *= torch.from_numpy(self.atoms[:, 4]).type(P.dtype).to(device)
+                xl *= torch.from_numpy(self.atoms[:, 4]).type(P.dtype).to(device)
 
             # Each pixel is set to the overlap of a shifted rectangle in that pixel
             P.scatter_add_(0, ielement + islice + yc + xc, yh * xh)
@@ -607,8 +629,8 @@ class crystal:
 
         # Return rotated crystal
         return new
-    
-    def rot90(self, k=1, axes=(0,1)):
+
+    def rot90(self, k=1, axes=(0, 1)):
         """Rotates a crystal by 90 degrees in the plane specified by axes.
 
         Rotation direction is from the first towards the second axis.
@@ -621,24 +643,27 @@ class crystal:
             The array is rotated in the plane defined by the axes.
             Axes must be different."""
 
-        #Much of the following is adapted from the numpy.rot90 function
+        # Much of the following is adapted from the numpy.rot90 function
         axes = tuple(axes)
-        if len(axes) != 2: raise ValueError("len(axes) must be 2.")
+        if len(axes) != 2:
+            raise ValueError("len(axes) must be 2.")
 
         k %= 4
-        
+
         if k == 0:
-            #Do nothing
+            # Do nothing
             return
         if k == 2:
-            #Reflect in both axes
+            # Reflect in both axes
             self.reflect(axes)
             return
 
         axes_list = np.arange(0, 3)
-        (axes_list[axes[0]], axes_list[axes[1]]) = (axes_list[axes[1]],
-                                                    axes_list[axes[0]])
-        
+        (axes_list[axes[0]], axes_list[axes[1]]) = (
+            axes_list[axes[1]],
+            axes_list[axes[0]],
+        )
+
         if k == 1:
             self.reflect([axes[1]])
             self.transpose(axes_list)
@@ -646,10 +671,9 @@ class crystal:
             # k == 3
             self.transpose(axes_list)
             self.reflect([axes[1]])
-        
 
-    def transpose(self,axes):
-        self.atoms[:,:3] = self.atoms[:,axes]
+    def transpose(self, axes):
+        self.atoms[:, :3] = self.atoms[:, axes]
         self.unitcell = self.unitcell[axes]
 
     def tile(self, x=1, y=1, z=1):
@@ -657,7 +681,7 @@ class crystal:
         # Make copy of original crystal
         # new = copy.deepcopy(self)
 
-        tiling = np.asarray([x,y,z])
+        tiling = np.asarray([x, y, z])
 
         # Get atoms in unit cell
         natoms = self.atoms.shape[0]
@@ -674,18 +698,20 @@ class crystal:
                 for l in range(int(z)):
 
                     # Calculate origin of this particular tile
-                    origin = np.asarray([j,k,l])
+                    origin = np.asarray([j, k, l])
 
                     # Calculate index of this particular tile
                     indx = j * int(y) * int(z) + k * int(z) + l
 
                     # Add new atoms to unit cell
-                    newatoms[indx*natoms : (indx+1)*natoms, :3] = (
+                    newatoms[indx * natoms : (indx + 1) * natoms, :3] = (
                         self.atoms[:, :3] + origin[np.newaxis, :]
-                    )/tiling[np.newaxis,:]
+                    ) / tiling[np.newaxis, :]
 
-                    #Copy other information about atoms
-                    newatoms[indx*natoms : (indx+1)*natoms, 3:] = self.atoms[:, 3:]
+                    # Copy other information about atoms
+                    newatoms[indx * natoms : (indx + 1) * natoms, 3:] = self.atoms[
+                        :, 3:
+                    ]
         self.atoms = newatoms
 
         # Return new crystal
@@ -742,7 +768,8 @@ class crystal:
 
     def reflect(self, axes):
         """Reflect crystal in each of the axes enumerated in list axes"""
-        for ax in axes: self.atoms[:, ax] = 1 - self.atoms[:, ax]
+        for ax in axes:
+            self.atoms[:, ax] = 1 - self.atoms[:, ax]
 
     def slice(self, range, axis):
         """Make a slice of crystal object ranging from range[0] to range[1] through

--- a/pyms/crystal.py
+++ b/pyms/crystal.py
@@ -354,7 +354,7 @@ class crystal:
         # Band-width limit the transmission function, see Earl Kirkland's book
         # for an discussion of why this is necessary
         for i in range(T.shape[0]):
-            T[i, ...] = bandwidth_limit_array(T[i, ...])
+            T[i] = bandwidth_limit_array(T[i])
 
         if fftout:
             return torch.ifft(T, signal_ndim=2)

--- a/pyms/py_multislice.py
+++ b/pyms/py_multislice.py
@@ -7,7 +7,12 @@ from re import split, match
 from os.path import splitext
 from .atomic_scattering_params import e_scattering_factors, atomic_symbol
 from .crystal import crystal
-from .utils.numpy_utils import bandwidth_limit_array, q_space_array,fourier_interpolate_2d,crop
+from .utils.numpy_utils import (
+    bandwidth_limit_array,
+    q_space_array,
+    fourier_interpolate_2d,
+    crop,
+)
 from .utils.torch_utils import (
     sinc,
     roll_n,
@@ -20,7 +25,8 @@ from .utils.torch_utils import (
     amplitude,
 )
 
-def make_propagators(pixelsize, gridsize, eV, subslices = [1.0]):
+
+def make_propagators(pixelsize, gridsize, eV, subslices=[1.0]):
     """Make the Fresnel freespace propagators for a multislice simulation.
 
     Keyword arguments:
@@ -156,7 +162,7 @@ def multislice(
     device_type=None,
     seed=None,
     return_numpy=True,
-    qspace_out = False
+    qspace_out=False,
 ):
     """For a given probe or set of probes, propagators, and transmission 
         functions perform the multislice algorithm for nslices iterations."""
@@ -206,9 +212,7 @@ def multislice(
             elif nopiy % tiling[0] == 0 and nopix % tiling[1] == 0:
                 # Shift an integer number of pixels in y
                 T_ = roll_n(
-                    T[it, subslice],
-                    0,
-                    r.randint(0, tiling[0]) * (nopiy // tiling[0]),
+                    T[it, subslice], 0, r.randint(0, tiling[0]) * (nopiy // tiling[0])
                 )
 
                 # Shift an integer number of pixels in x
@@ -224,7 +228,9 @@ def multislice(
 
                 # Generate an array to perform Fourier shift of transmission
                 # function
-                FFT_shift_array = fourier_shift_array([nopiy, nopix], shift, dtype=T.dtype, device=T.device)
+                FFT_shift_array = fourier_shift_array(
+                    [nopiy, nopix], shift, dtype=T.dtype, device=T.device
+                )
 
                 # Apply Fourier shift theorem for sub-pixel shift
                 T_ = torch.ifft(
@@ -239,10 +245,12 @@ def multislice(
 
             # Propagate and inverse Fourier transform
             psi = complex_mul(psi, P[subslice])
-            
-            if not np.all([qspace_out, islice == nslices-1,subslice == nsubslices-1]): 
-                psi = torch.ifft(psi,signal_ndim=2)
-            
+
+            if not np.all(
+                [qspace_out, islice == nslices - 1, subslice == nsubslices - 1]
+            ):
+                psi = torch.ifft(psi, signal_ndim=2)
+
     if return_numpy:
         return cx_to_numpy(psi)
     return psi
@@ -278,7 +286,7 @@ def STEM(
     nslices,
     eV,
     alpha,
-    S = None,
+    S=None,
     batch_size=1,
     detectors=None,
     FourD_STEM=False,
@@ -322,7 +330,7 @@ def STEM(
     seed        -- Seed for the random number generator for frozen phonon 
                     configurations
     showProgress-- Pass showProgress=False to disable progress bar.
-    """         
+    """
     from .Probe import nyquist_sampling
 
     # Get number of thicknesses in the series
@@ -346,7 +354,7 @@ def STEM(
 
         # Calculate number of scan positions in STEM scan
         nscan = nyquist_sampling(FOV, eV=eV, alpha=alpha)
-        
+
         # Get scan position in pixel coordinates
         scan_posn = []
         # Y scan coordinates
@@ -388,27 +396,31 @@ def STEM(
     # Initialize array in which to store resulting 4D-STEM datacube if required
     return_datacube = False
     if FourD_STEM:
-        
-        #Check whether a resampling directive has been given
-        if isinstance(FourD_STEM,(list,tuple)):
-            #Get output grid and diffraction space size of that grid from tuple
+
+        # Check whether a resampling directive has been given
+        if isinstance(FourD_STEM, (list, tuple)):
+            # Get output grid and diffraction space size of that grid from tuple
             gridout = FourD_STEM[0]
             sizeout = FourD_STEM[1]
-            
+
             #
-            diff_pat_crop = np.round(np.asarray(sizeout)*np.asarray(rsize[:2])).astype(np.int)
-                        
-            #Define resampling function
-            resize = lambda array: fourier_interpolate_2d(crop(array,diff_pat_crop),gridout)
+            diff_pat_crop = np.round(
+                np.asarray(sizeout) * np.asarray(rsize[:2])
+            ).astype(np.int)
+
+            # Define resampling function
+            resize = lambda array: fourier_interpolate_2d(
+                crop(array, diff_pat_crop), gridout
+            )
         else:
-            #If no resampling then the output size is just the simulation
-            #grid size
+            # If no resampling then the output size is just the simulation
+            # grid size
             gridout = gridshape
-            #Define a do nothing function
+            # Define a do nothing function
             resize = lambda array: array
 
-        #Check whether a datacube is already provided or not
-        if datacube is None: 
+        # Check whether a datacube is already provided or not
+        if datacube is None:
             datacube = np.zeros((nthick, nscantot, *gridout))
             return_datacube = True
         else:
@@ -416,7 +428,6 @@ def STEM(
             # the reshape function `should` provide a new view of the object,
             # not a copy of the whole array
             datacube = datacube.reshape((nthick, nscantot, *gridout))
-
 
     # This algorithm allows for "batches" of probe to be sent through the
     # multislice algorithm to achieve some speed up at the cost of storing more
@@ -460,12 +471,13 @@ def STEM(
         # Apply shift to original probe
         probes = complex_mul(probe_.view(1, *probe_.size()), probes)
 
-        if(S is None): probes = torch.ifft(probes,signal_ndim=2)
+        if S is None:
+            probes = torch.ifft(probes, signal_ndim=2)
 
         # Thickness series
         for it, t in enumerate(nslices):
-            if(S is None):
-                
+            if S is None:
+
                 # Perform multislice
                 probes = multislice(
                     probes,
@@ -481,42 +493,47 @@ def STEM(
                 probes = torch.fft(probes, signal_ndim=2, normalized=True)
 
             else:
-                #Calculate STEM images using a scattering matrix
-                #TODO Implement PRISM thickness series
-                #Perform matrix multiplication of scattering matrix with
-                #probe vector
-                
-                probe_vec = complex_matmul(probes[:,S.beams[:,0],S.beams[:,1]],S.S)
+                # Calculate STEM images using a scattering matrix
+                # TODO Implement PRISM thickness series
+                # Perform matrix multiplication of scattering matrix with
+                # probe vector
 
-                #Now reshape output from vectors to square arrays
+                probe_vec = complex_matmul(probes[:, S.beams[:, 0], S.beams[:, 1]], S.S)
+
+                # Now reshape output from vectors to square arrays
                 probes[...] = 0
-                probes[:,S.bw_mapping[:,0],S.bw_mapping[:,1],:] = probe_vec
-                
-                
-                #Apply PRISM cropping in real space if appropriate
-                if(np.any([S.PRISM_factor[i]>1 for i in [0,1]])):
-                    #Transform probe to real space
-                    probes = torch.ifft(probes,signal_ndim=2)
-                    
-                    #Distance function to calculate windows about scan positions
-                    dist = lambda x,X: np.abs((np.arange(X)-x+X//2)%X-X//2)
+                probes[:, S.bw_mapping[:, 0], S.bw_mapping[:, 1], :] = probe_vec
+
+                # Apply PRISM cropping in real space if appropriate
+                if np.any([S.PRISM_factor[i] > 1 for i in [0, 1]]):
+                    # Transform probe to real space
+                    probes = torch.ifft(probes, signal_ndim=2)
+
+                    # Distance function to calculate windows about scan positions
+                    dist = lambda x, X: np.abs((np.arange(X) - x + X // 2) % X - X // 2)
 
                     for k in range(K):
-                        
-                        #Calculate windows in vertical and horizontal directions
-                        ywindow = dist(yscan[k],gridshape[0])<=gridshape[0]/S.PRISM_factor[0]/2
-                        xwindow = dist(xscan[k],gridshape[1])<=gridshape[1]/S.PRISM_factor[1]/2
 
-                        #Set array values outside windows to zero
-                        probes[k,np.logical_not(ywindow),...] = 0
-                        probes[k,:,np.logical_not(xwindow),:] = 0
-                    
-                    #Transform probe back to Fourier space
-                    probes = torch.fft(probes,signal_ndim=2)
+                        # Calculate windows in vertical and horizontal directions
+                        ywindow = (
+                            dist(yscan[k], gridshape[0])
+                            <= gridshape[0] / S.PRISM_factor[0] / 2
+                        )
+                        xwindow = (
+                            dist(xscan[k], gridshape[1])
+                            <= gridshape[1] / S.PRISM_factor[1] / 2
+                        )
+
+                        # Set array values outside windows to zero
+                        probes[k, np.logical_not(ywindow), ...] = 0
+                        probes[k, :, np.logical_not(xwindow), :] = 0
+
+                    # Transform probe back to Fourier space
+                    probes = torch.fft(probes, signal_ndim=2)
 
             # Calculate amplitude of probes
             amp = amplitude(probes)
-            
+
             # Calculate STEM images
             if conventional_STEM:
                 # broadcast detector and probe arrays to
@@ -532,14 +549,17 @@ def STEM(
                 )
             # Store datacube
             if FourD_STEM:
-                datacube[it, scan_index] += resize(np.fft.fftshift(amp.cpu().numpy(),axes=(-1,-2)))
+                datacube[it, scan_index] += resize(
+                    np.fft.fftshift(amp.cpu().numpy(), axes=(-1, -2))
+                )
 
             # Fourier transform probes back to real space
             if it < len(nslices):
                 probes = torch.ifft(probes, signal_ndim=2, normalized=True)
 
-    #Unflatten 4D-STEM datacube scan dimensions
-    if FourD_STEM : datacube = datacube.reshape(nthick, *nscan, *gridout)
+    # Unflatten 4D-STEM datacube scan dimensions
+    if FourD_STEM:
+        datacube = datacube.reshape(nthick, *nscan, *gridout)
 
     if conventional_STEM and return_datacube:
         return STEM_image.reshape(ndet, nthick, *nscan), datacube
@@ -574,9 +594,10 @@ def max_grid_resolution(gridshape, rsize, bandwidthlimit=2 / 3, eV=None):
 
     return max_res / wavev(eV) * 1e3
 
-class scattering_matrix:
 
-    def __init__(self,
+class scattering_matrix:
+    def __init__(
+        self,
         rsize,
         propagators,
         transmission_functions,
@@ -586,15 +607,15 @@ class scattering_matrix:
         batch_size=1,
         device=None,
         PRISM_factor=[1, 1],
-        tiling = [1,1],
+        tiling=[1, 1],
         device_type=None,
         seed=None,
         showProgress=True,
-        bandwidth_limit=2/3
+        bandwidth_limit=2 / 3,
     ):
         """Make a scattering matrix for dynamical scattering calculations using 
         the PRISM algorithm"""
-        
+
         from .Probe import wavev, plane_wave_illumination
 
         # Get size of grid
@@ -612,35 +633,42 @@ class scattering_matrix:
 
         # Make a list of beams in the scattering matrix
         q = q_space_array(gridshape, rsize)
-        self.beams = np.argwhere(np.logical_and(
+        self.beams = np.argwhere(
             np.logical_and(
-                np.less_equal(q[0] ** 2 + q[1] ** 2, self.alpha_),
+                np.logical_and(
+                    np.less_equal(q[0] ** 2 + q[1] ** 2, self.alpha_),
+                    (
+                        np.mod(
+                            np.fft.fftfreq(gridshape[0], d=1 / gridshape[0]).astype(
+                                np.int
+                            ),
+                            PRISM_factor[0],
+                        )
+                        == 0
+                    )[:, np.newaxis],
+                ),
                 (
                     np.mod(
-                        np.fft.fftfreq(gridshape[0], d=1 / gridshape[0]).astype(np.int),
-                        PRISM_factor[0],
+                        np.fft.fftfreq(gridshape[1], d=1 / gridshape[1]).astype(np.int),
+                        PRISM_factor[1],
                     )
                     == 0
-                )[:, np.newaxis],
-            ),
-            (
-                np.mod(
-                    np.fft.fftfreq(gridshape[1], d=1 / gridshape[1]).astype(np.int),
-                    PRISM_factor[1],
-                )
-                == 0
-            )[np.newaxis, :],
-        ))
+                )[np.newaxis, :],
+            )
+        )
         nbeams = self.beams.shape[0]
 
-        #We will only store output of the scattering matrix up to the band
-        #width limit of the calculation, since this is a circular band-width
-        #limit on a square grid we have to get somewhat fancy and store a mapping
-        #of the pixels within the bandwidth limit to a one-dimensional vector
-        self.bw_mapping = np.argwhere((np.fft.fftfreq(gridshape[0])**2)[:,np.newaxis]
-                                    +(np.fft.fftfreq(gridshape[1])**2)[np.newaxis,:]<(bandwidth_limit/2)**2)
+        # We will only store output of the scattering matrix up to the band
+        # width limit of the calculation, since this is a circular band-width
+        # limit on a square grid we have to get somewhat fancy and store a mapping
+        # of the pixels within the bandwidth limit to a one-dimensional vector
+        self.bw_mapping = np.argwhere(
+            (np.fft.fftfreq(gridshape[0]) ** 2)[:, np.newaxis]
+            + (np.fft.fftfreq(gridshape[1]) ** 2)[np.newaxis, :]
+            < (bandwidth_limit / 2) ** 2
+        )
         self.nbout = self.bw_mapping.shape[0]
-        
+
         # Initialize scattering matrix
         self.S = torch.zeros(nbeams, self.nbout, 2, dtype=dtype, device=device)
 
@@ -652,14 +680,21 @@ class scattering_matrix:
 
         # Initialize probe wave function array
         psi = torch.zeros(batch_size, *gridshape, 2, dtype=dtype, device=device)
-        
-        for i in tqdm(range(int(np.ceil(nbeams / batch_size))), disable=not showProgress):
+
+        for i in tqdm(
+            range(int(np.ceil(nbeams / batch_size))), disable=not showProgress
+        ):
             for j in range(batch_size):
                 jj = j + batch_size * i
-                psi[j] = cx_from_numpy(plane_wave_illumination(
-                    gridshape, rsize[:2], tilt=self.beams[jj, :], tilt_units="pixels"
-                ))
-            
+                psi[j] = cx_from_numpy(
+                    plane_wave_illumination(
+                        gridshape,
+                        rsize[:2],
+                        tilt=self.beams[jj, :],
+                        tilt_units="pixels",
+                    )
+                )
+
             psi = multislice(
                 psi,
                 propagators,
@@ -669,36 +704,48 @@ class scattering_matrix:
                 device,
                 seed,
                 return_numpy=False,
-                qspace_out=True
+                qspace_out=True,
             )
-            
-            self.S[i * batch_size : (i + 1) * batch_size] = psi[:,self.bw_mapping[:,0],self.bw_mapping[:,1],:]
-        
+
+            self.S[i * batch_size : (i + 1) * batch_size] = psi[
+                :, self.bw_mapping[:, 0], self.bw_mapping[:, 1], :
+            ]
+
         self.gridshape = gridshape
         self.PRISM_factor = PRISM_factor
 
-    def plot(self,show=True):
+    def plot(self, show=True):
         """Make a montage plot of the scattering matrix"""
         from .utils import colorize
 
-        nopiy,nopix = self.gridshape
+        nopiy, nopix = self.gridshape
 
-        yind = (self.beams[:,0]+np.amax(self.beams[self.beams[:,0]<nopiy//2,0]))%nopiy//self.PRISM_factor[0]
-        xind = (self.beams[:,1]+np.amax(self.beams[self.beams[:,1]<nopix//2,1]))%nopix//self.PRISM_factor[1]
-        
-        nrows=max(yind)+1
-        ncols=max(xind)+1
+        yind = (
+            (self.beams[:, 0] + np.amax(self.beams[self.beams[:, 0] < nopiy // 2, 0]))
+            % nopiy
+            // self.PRISM_factor[0]
+        )
+        xind = (
+            (self.beams[:, 1] + np.amax(self.beams[self.beams[:, 1] < nopix // 2, 1]))
+            % nopix
+            // self.PRISM_factor[1]
+        )
 
-        fig,ax = plt.subplots(nrows=nrows,ncols=ncols)
+        nrows = max(yind) + 1
+        ncols = max(xind) + 1
 
-        for i in range(nrows*ncols): ax[i%nrows,i//nrows].set_axis_off()
+        fig, ax = plt.subplots(nrows=nrows, ncols=ncols)
+
+        for i in range(nrows * ncols):
+            ax[i % nrows, i // nrows].set_axis_off()
 
         for ibeam in range(self.beams.shape[0]):
-            S = torch.zeros((nopiy,nopix,2),dtype=self.S.dtype,device=self.S.device)
-            S[self.bw_mapping[:,0],self.bw_mapping[:,1],:] =self.S[ibeam,...]
-            
-            S =  torch.ifft(S,signal_ndim=2).cpu()
-            ax[yind[ibeam],xind[ibeam]].imshow(colorize(cx_to_numpy(S)))
+            S = torch.zeros((nopiy, nopix, 2), dtype=self.S.dtype, device=self.S.device)
+            S[self.bw_mapping[:, 0], self.bw_mapping[:, 1], :] = self.S[ibeam, ...]
 
-        if show: plt.show(block=True)
+            S = torch.ifft(S, signal_ndim=2).cpu()
+            ax[yind[ibeam], xind[ibeam]].imshow(colorize(cx_to_numpy(S)))
+
+        if show:
+            plt.show(block=True)
         return fig

--- a/pyms/py_multislice.py
+++ b/pyms/py_multislice.py
@@ -101,14 +101,14 @@ def multislice_cupy(
             # Transmit and forward Fourier transform
 
             if tiling is None or (tiling[0] == 1 & tiling[1] == 1):
-                psi = cp.fft.fft2(T[it, subslice, ...] * psi)
+                psi = cp.fft.fft2(T[it, subslice] * psi)
                 # If the transmission function is from a tiled unit cell then
                 # there is the option of randomly shifting it around to
                 # generate "more" transmission functions
             elif nopiy % tiling[0] == 0 and nopix % tiling[1] == 0:
                 # Shift an integer number of pixels in y and x
                 T_ = cp.roll(
-                    T[it, subslice, ...],
+                    T[it, subslice],
                     (
                         r.randint(0, tiling[0]) * (nopiy // tiling[0]),
                         r.randint(1, tiling[1]) * (nopix // tiling[1]),
@@ -131,7 +131,7 @@ def multislice_cupy(
                 # Apply Fourier shift theorem for sub-pixel shift
                 T_ = torch.ifft(
                     complex_mul(
-                        FFT_shift_array, torch.fft(T[it, subslice, ...], signal_ndim=2)
+                        FFT_shift_array, torch.fft(T[it, subslice], signal_ndim=2)
                     ),
                     signal_ndim=2,
                 )
@@ -140,7 +140,7 @@ def multislice_cupy(
                 psi = torch.fft(complex_mul(T_, psi), signal_ndim=2)
 
             # Propagate and inverse Fourier transform
-            psi = torch.ifft(complex_mul(psi, P[subslice, ...]), signal_ndim=2)
+            psi = torch.ifft(complex_mul(psi, P[subslice]), signal_ndim=2)
 
     if return_numpy:
         return cx_to_numpy(psi)
@@ -199,14 +199,14 @@ def multislice(
             # Transmit and forward Fourier transform
 
             if tiling is None or (tiling[0] == 1 & tiling[1] == 1):
-                psi = torch.fft(complex_mul(T[it, subslice, ...], psi), signal_ndim=2)
+                psi = torch.fft(complex_mul(T[it, subslice], psi), signal_ndim=2)
                 # If the transmission function is from a tiled unit cell then
                 # there is the option of randomly shifting it around to
                 # generate "more" transmission functions
             elif nopiy % tiling[0] == 0 and nopix % tiling[1] == 0:
                 # Shift an integer number of pixels in y
                 T_ = roll_n(
-                    T[it, subslice, ...],
+                    T[it, subslice],
                     0,
                     r.randint(0, tiling[0]) * (nopiy // tiling[0]),
                 )
@@ -229,7 +229,7 @@ def multislice(
                 # Apply Fourier shift theorem for sub-pixel shift
                 T_ = torch.ifft(
                     complex_mul(
-                        FFT_shift_array, torch.fft(T[it, subslice, ...], signal_ndim=2)
+                        FFT_shift_array, torch.fft(T[it, subslice], signal_ndim=2)
                     ),
                     signal_ndim=2,
                 )
@@ -238,7 +238,7 @@ def multislice(
                 psi = torch.fft(complex_mul(T_, psi), signal_ndim=2)
 
             # Propagate and inverse Fourier transform
-            psi = complex_mul(psi, P[subslice, ...])
+            psi = complex_mul(psi, P[subslice])
             
             if not np.all([qspace_out, islice == nslices-1,subslice == nsubslices-1]): 
                 psi = torch.ifft(psi,signal_ndim=2)
@@ -532,7 +532,7 @@ def STEM(
                 )
             # Store datacube
             if FourD_STEM:
-                datacube[it, scan_index, ...] += resize(np.fft.fftshift(amp.cpu().numpy(),axes=(-1,-2)))
+                datacube[it, scan_index] += resize(np.fft.fftshift(amp.cpu().numpy(),axes=(-1,-2)))
 
             # Fourier transform probes back to real space
             if it < len(nslices):
@@ -656,7 +656,7 @@ class scattering_matrix:
         for i in tqdm(range(int(np.ceil(nbeams / batch_size))), disable=not showProgress):
             for j in range(batch_size):
                 jj = j + batch_size * i
-                psi[j, ...] = cx_from_numpy(plane_wave_illumination(
+                psi[j] = cx_from_numpy(plane_wave_illumination(
                     gridshape, rsize[:2], tilt=self.beams[jj, :], tilt_units="pixels"
                 ))
             
@@ -672,7 +672,7 @@ class scattering_matrix:
                 qspace_out=True
             )
             
-            self.S[i * batch_size : (i + 1) * batch_size, ...] = psi[:,self.bw_mapping[:,0],self.bw_mapping[:,1],:]
+            self.S[i * batch_size : (i + 1) * batch_size] = psi[:,self.bw_mapping[:,0],self.bw_mapping[:,1],:]
         
         self.gridshape = gridshape
         self.PRISM_factor = PRISM_factor

--- a/pyms/utils/numpy_utils.py
+++ b/pyms/utils/numpy_utils.py
@@ -1,6 +1,7 @@
 import numpy as np
 import torch
 
+
 def q_space_array(pixels, gridsize):
     """Returns the appropriately scaled 2D reciprocal space array for pixel size
     given by pixels (#y pixels, #x pixels) and real space size given by gridsize
@@ -39,8 +40,8 @@ def bandwidth_limit_array(array, limit=2 / 3):
 
     return array
 
-    
-def fourier_interpolate_2d(ain,shapeout):
+
+def fourier_interpolate_2d(ain, shapeout):
     """Perfoms a fourier interpolation on array ain so that its shape matches
     that given by shapeout.
 
@@ -48,119 +49,144 @@ def fourier_interpolate_2d(ain,shapeout):
     ain      -- Input numpy array
     shapeout -- Shape of output array
     """
-    #Import required FFT functions
-    from numpy.fft import fftshift,fft2,ifft2
+    # Import required FFT functions
+    from numpy.fft import fftshift, fft2, ifft2
 
-    #Make input complex
-    aout = np.zeros(np.shape(ain)[:-2]+tuple(shapeout),dtype=np.complex)
+    # Make input complex
+    aout = np.zeros(np.shape(ain)[:-2] + tuple(shapeout), dtype=np.complex)
 
-    #Get input dimensions
-    npiyin,npixin = np.shape(ain)[-2:]
-    npiyout,npixout = shapeout
+    # Get input dimensions
+    npiyin, npixin = np.shape(ain)[-2:]
+    npiyout, npixout = shapeout
 
-    #Construct input and output fft grids
-    qyin,qxin,qyout,qxout  = [(np.fft.fftfreq(x,1/x ) ).astype(np.int) 
-                              for x in [npiyin,npixin,npiyout,npixout]]
-    
-    #Get maximum and minimum common reciprocal space coordinates
-    minqy,maxqy = [max(np.amin(qyin),np.amin(qyout)),min(np.amax(qyin),np.amax(qyout))]
-    minqx,maxqx = [max(np.amin(qxin),np.amin(qxout)),min(np.amax(qxin),np.amax(qxout))]
+    # Construct input and output fft grids
+    qyin, qxin, qyout, qxout = [
+        (np.fft.fftfreq(x, 1 / x)).astype(np.int)
+        for x in [npiyin, npixin, npiyout, npixout]
+    ]
 
-    #Make 2d grids
-    qqxout,qqyout = np.meshgrid(qxout,qyout)
-    qqxin ,qqyin  = np.meshgrid(qxin ,qyin )
+    # Get maximum and minimum common reciprocal space coordinates
+    minqy, maxqy = [
+        max(np.amin(qyin), np.amin(qyout)),
+        min(np.amax(qyin), np.amax(qyout)),
+    ]
+    minqx, maxqx = [
+        max(np.amin(qxin), np.amin(qxout)),
+        min(np.amax(qxin), np.amax(qxout)),
+    ]
 
-    #Make a masks of common Fourier components for input and output arrays
-    maskin = np.logical_and(np.logical_and(qqxin <= maxqx,qqxin >= minqx),
-                            np.logical_and(qqyin <= maxqy,qqyin >= minqy))
-    
-    maskout = np.logical_and(np.logical_and(qqxout <= maxqx,qqxout >= minqx),
-                             np.logical_and(qqyout <= maxqy,qqyout >= minqy))
-    
-    #Now transfer over Fourier coefficients from input to output array
-    aout[...,maskout] = fft2(np.asarray(ain,dtype=np.complex))[...,maskin]
+    # Make 2d grids
+    qqxout, qqyout = np.meshgrid(qxout, qyout)
+    qqxin, qqyin = np.meshgrid(qxin, qyin)
 
-    #Fourier transform result with appropriate normalization
-    aout = ifft2(aout)*(1.0*np.prod(shapeout)/np.prod(np.shape(ain)[-2:]))
-    #Return correct array data type
-    if (str(ain.dtype) in ['float64','float32','float','f'] or str(ain.dtype)[1] == 'f'): return np.real(aout)
-    else: return aout
+    # Make a masks of common Fourier components for input and output arrays
+    maskin = np.logical_and(
+        np.logical_and(qqxin <= maxqx, qqxin >= minqx),
+        np.logical_and(qqyin <= maxqy, qqyin >= minqy),
+    )
 
-def oned_shift(len,shift):
-    '''Constructs a one dimensional shift array of array size 
-    len that shifts an array number of pixels given by shift.'''
-    #Check if the pixel length is even or not
-    even = len%2 == 0
-    
-    #Create the Fourier space pixel coordinates of the shift 
-    #array
-    if (even):
-        shiftarray = np.empty((len))
-        shiftarray[:len/2] = np.arange(len/2)
-        shiftarray[len/2:] = np.arange(-len/2,0)
+    maskout = np.logical_and(
+        np.logical_and(qqxout <= maxqx, qqxout >= minqx),
+        np.logical_and(qqyout <= maxqy, qqyout >= minqy),
+    )
+
+    # Now transfer over Fourier coefficients from input to output array
+    aout[..., maskout] = fft2(np.asarray(ain, dtype=np.complex))[..., maskin]
+
+    # Fourier transform result with appropriate normalization
+    aout = ifft2(aout) * (1.0 * np.prod(shapeout) / np.prod(np.shape(ain)[-2:]))
+    # Return correct array data type
+    if (
+        str(ain.dtype) in ["float64", "float32", "float", "f"]
+        or str(ain.dtype)[1] == "f"
+    ):
+        return np.real(aout)
     else:
-        shiftarray = np.arange(-len/2+1,len/2+1)
-    
-    #The shift array is given mathematically as e^(-2pi i k 
-    #Delta x) and this is what is returned.
-    return np.exp(-2*np.pi*1j*shiftarray*shift)
-    
-def fourier_shift(arrayin, shift,qspace = False):
-    '''Shifts a 2d array by an amount given in the tuple shift 
-    using the Fourier shift theorem.'''
-    
-    #Get shift amounts and array dimensions from input
-    shifty,shiftx = shift
-    y,x = np.shape(arrayin)[-2:]
-    
-    #Construct shift array
-    shifty = oned_shift(y,shifty)
-    shiftx = oned_shift(x,shiftx)
-    shiftarray = shiftx[np.newaxis,:]*shifty[:,np.newaxis]
+        return aout
 
-    #Now Fourier transform array and apply shift
+
+def oned_shift(len, shift):
+    """Constructs a one dimensional shift array of array size 
+    len that shifts an array number of pixels given by shift."""
+    # Check if the pixel length is even or not
+    even = len % 2 == 0
+
+    # Create the Fourier space pixel coordinates of the shift
+    # array
+    if even:
+        shiftarray = np.empty((len))
+        shiftarray[: len / 2] = np.arange(len / 2)
+        shiftarray[len / 2 :] = np.arange(-len / 2, 0)
+    else:
+        shiftarray = np.arange(-len / 2 + 1, len / 2 + 1)
+
+    # The shift array is given mathematically as e^(-2pi i k
+    # Delta x) and this is what is returned.
+    return np.exp(-2 * np.pi * 1j * shiftarray * shift)
+
+
+def fourier_shift(arrayin, shift, qspace=False):
+    """Shifts a 2d array by an amount given in the tuple shift 
+    using the Fourier shift theorem."""
+
+    # Get shift amounts and array dimensions from input
+    shifty, shiftx = shift
+    y, x = np.shape(arrayin)[-2:]
+
+    # Construct shift array
+    shifty = oned_shift(y, shifty)
+    shiftx = oned_shift(x, shiftx)
+    shiftarray = shiftx[np.newaxis, :] * shifty[:, np.newaxis]
+
+    # Now Fourier transform array and apply shift
     real = array_real(arrayin)
-    if real: array = np.asarray(arrayin,dtype= np.complex)
-    else: array = arrayin
-    
-    if qspace: array = ifft2(shiftarray*array)
-    else: array = ifft2(shiftarray*fft2(array))
-    
-    if real: return np.real(array)
-    else: return array
+    if real:
+        array = np.asarray(arrayin, dtype=np.complex)
+    else:
+        array = arrayin
 
-def crop(arrayin,shapeout):
+    if qspace:
+        array = ifft2(shiftarray * array)
+    else:
+        array = ifft2(shiftarray * fft2(array))
+
+    if real:
+        return np.real(array)
+    else:
+        return array
+
+
+def crop(arrayin, shapeout):
     """Crop the last two dimensions of arrayin to grid size shapeout. For 
     entries of shapeout which are larger than the shape of the input array,
     perform zero-padding"""
-    #Number of dimensions in input array
+    # Number of dimensions in input array
     ndim = arrayin.ndim
 
-    #Number of dimensions not covered by shapeout (ie not to be cropped)
+    # Number of dimensions not covered by shapeout (ie not to be cropped)
     nUntouched = ndim - 2
 
-    #Shape of output array
-    shapeout_ = arrayin.shape[:nUntouched]+tuple(shapeout)
-    
-    arrayout = np.zeros(shapeout_,
-                        dtype=arrayin.dtype)
+    # Shape of output array
+    shapeout_ = arrayin.shape[:nUntouched] + tuple(shapeout)
 
-    y,x   = arrayin.shape[-2:]
-    y_,x_ = shapeout[-2:]
-    
-    def indices(y,y_):
-        if y>y_:
-            #Crop in y dimension
-            y1,y2 = [(y-y_)//2,(y+y_)//2]
-            y1_,y2_ = [0,y_]
+    arrayout = np.zeros(shapeout_, dtype=arrayin.dtype)
+
+    y, x = arrayin.shape[-2:]
+    y_, x_ = shapeout[-2:]
+
+    def indices(y, y_):
+        if y > y_:
+            # Crop in y dimension
+            y1, y2 = [(y - y_) // 2, (y + y_) // 2]
+            y1_, y2_ = [0, y_]
         else:
-            #Zero pad in y dimension
-            y1,y2 = [0,y]
-            y1_,y2_ = [(y_-y)//2,(y+y_)//2]
-        return y1,y2,y1_,y2_
+            # Zero pad in y dimension
+            y1, y2 = [0, y]
+            y1_, y2_ = [(y_ - y) // 2, (y + y_) // 2]
+        return y1, y2, y1_, y2_
 
-    y1,y2,y1_,y2_ = indices(y,y_)
-    x1,x2,x1_,x2_ = indices(x,x_)
+    y1, y2, y1_, y2_ = indices(y, y_)
+    x1, x2, x1_, x2_ = indices(x, x_)
 
-    arrayout[...,y1_:y2_,x1_:x2_] = arrayin[...,y1:y2,x1:x2]
+    arrayout[..., y1_:y2_, x1_:x2_] = arrayin[..., y1:y2, x1:x2]
     return arrayout

--- a/pyms/utils/torch_utils.py
+++ b/pyms/utils/torch_utils.py
@@ -14,6 +14,7 @@ def check_complex(A):
                 "taking complex_mul of non-complex tensor! a.shape " + str(a.shape)
             )
 
+
 def complex_matmul(a: torch.Tensor, b: torch.Tensor, conjugate=False) -> torch.Tensor:
     """Complex matrix multiplication of tensors a and b. Pass conjugate = True
     to conjugate tensor b in the multiplication."""
@@ -52,20 +53,21 @@ def complex_mul(a: torch.Tensor, b: torch.Tensor, conjugate=False) -> torch.Tens
 
 def colorize(z, ccc=None, max=None, min=None):
     from colorsys import hls_to_rgb
-    #Get shape of array
+
+    # Get shape of array
     n, m = z.shape
-    
-    #Intialize RGB array
+
+    # Intialize RGB array
     c = np.zeros((n, m, 3))
 
-    #Set infinite and nan values to constant
+    # Set infinite and nan values to constant
     c[np.isinf(z)] = (1.0, 1.0, 1.0)
     c[np.isnan(z)] = (0.5, 0.5, 0.5)
 
     idx = ~(np.isinf(z) + np.isnan(z))
-    #Map phase to float between 0 and 1 and store in array A
-    A = ((np.angle(z[idx])) / (2 * np.pi))%1.0
-    
+    # Map phase to float between 0 and 1 and store in array A
+    A = ((np.angle(z[idx])) / (2 * np.pi)) % 1.0
+
     B = np.ones_like(A)
     if min is None:
         min_ = np.abs(z).min()


### PR DESCRIPTION
Hi Hamish,

Two small things in this PR:
First off, in Python you don't need to reference all axes in an array when doing array slicing. Unlike in Matlab, A[1,:,:] is equivalent to A[1].

As an example:
```python
>>> import torch
>>> A = torch.randn(3,3,3)
>>> print((A[1,:,:] == A[1]).cpu().numpy().all())
True
>>> print((A[1,...] == A[1]).cpu().numpy().all())
True
```

Second thing in this PR is formatting using the Black formatter. I'm in the habit of formatting code automatically, and realised that it was making future PRs very noisy as the `git diff` would show changes across functions that I hadn't changed, but had formatted.